### PR TITLE
Removed /network endpoint from cy.visit()

### DIFF
--- a/cypress/integration/Practice/network-requests.spec.js
+++ b/cypress/integration/Practice/network-requests.spec.js
@@ -13,7 +13,7 @@ describe("Network Requests", () => {
       delete req.headers["if-none-match"];
     }).as("posts");
 
-    cy.visit("http://localhost:3000/network");
+    cy.visit("http://localhost:3000");
   });
 
   it("/api/posts returns a status code of 200", () => {


### PR DESCRIPTION
I was having a hard time finding the issue. Then I compared the practice file to the one in the answers folder and noticed the /network endpoint was not in the cy.visit() url. So I removed it from the practice file